### PR TITLE
Changes for version 2.0.1

### DIFF
--- a/broadly.php
+++ b/broadly.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Broadly for WordPress
-Description: Dynamic integration of your Broadly reviews within your existing WordPress website. 
+Description: Dynamic integration of your Broadly reviews within your existing WordPress website.
 Plugin URL: http://broadly.com
 Author: Broadly
 Author URI: http://broadly.com/
@@ -10,27 +10,27 @@ License: GPLv2 or later
 */
 
 if ( ! class_exists( 'Broadly_Plugin' ) ) {
-	
+
 	/**
 	 * Main Broadly Plugin class
-	 * 
-	 * Responsible for the frontend review management and backend  
+	 *
+	 * Responsible for the frontend review management and backend
 	 * settings for the plugin.
-	 * 
+	 *
 	 * @author nofearinc
 	 *
 	 */
 	class Broadly_Plugin {
 
 		public static $version = '2.0.1';
-	
+
 		function __construct() {
 			// Creating the admin menu
 			add_action( 'admin_menu', array( $this, 'broadly_menu' ) );
-			
+
 			// Register the Settings fields
 			add_action( 'admin_init', array( $this, 'broadly_settings_init' ) );
-			
+
 			// Replace the Broadly scripts with the prefetched HTML
 			add_filter( 'the_content', array( $this, 'replace_js' ) );
 		}
@@ -39,30 +39,30 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 		 * Register a menu page for Broadly under Settings
 		 */
 		public function broadly_menu() {
-			add_options_page( __('Broadly', 'broadly' ), 
+			add_options_page( __('Broadly', 'broadly' ),
 					__( 'Broadly Setup', 'broadly' ),
 					'manage_options', 'broadly', array( $this, 'broadly_menu_cb' ) );
 		}
-		
+
 		/**
 		 * Settings class initialization
 		 */
 		public function broadly_settings_init() {
 			include_once 'settings.class.php';
 		}
-		
+
 		/**
 		 * Menu page callback - render the UI form for the admin
 		 */
 		public function broadly_menu_cb() {
 			$broadly_options = get_option( 'broadly_options', array() );
-			
+
 			include_once 'settings-page.php';
 		}
 
 		/**
 		 * Replace the JS snippet with the prefetched reviews
-		 * 
+		 *
 		 * @param string $content the existing page content
 		 * @return string $content the updated page content if a script is found
 		 */
@@ -72,29 +72,29 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 
 			// Proceed further only if a match is found - false will handle both 0 and false
 			if ( false != $matches_count ) {
-				
+
 				// Iterate through all of the matches if more scripts are injected
 				for ( $current_match = 0; $current_match < $matches_count; $current_match++ ) {
-					
+
 					// Fetch the entire script and the data-url match
 					$script_match = $matches[0][$current_match];
 					$dataurl_match = $matches[1][$current_match];
-					
-					// Append the data-url and build the reviews URL
-					$broadly_reviews_url = 'http://embed.broadly.com/' . $dataurl_match;
-		
+
+					// Append the data-url and build the embed URL
+					$broadly_embed_url = 'http://embed.broadly.com/' . $dataurl_match;
+
 					$args = array();
 					/**
 					 * Hook the arguments for the remote call.
-					 * 
+					 *
 					 * If needed, we can disable SSL or update the other HTTP arguments.
 					 */
 					$args = apply_filters( 'broadly_ssl_args', $args );
-		
+
 					add_filter( 'http_request_args', array( $this, 'filter_broadly_headers' ), 10, 2 );
-					$response = wp_remote_get( $broadly_reviews_url, $args );
+					$response = wp_remote_get( $broadly_embed_url, $args );
 					remove_filter( 'http_request_args', array( $this, 'filter_broadly_headers' ), 10 );
-					
+
 					// Verify for errors - not being sent for reporting yet
 					$error = null;
 					if ( is_wp_error( $response ) ) {
@@ -106,7 +106,7 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 							$error = __( 'No body tag in the response', 'broadly' );
 						}
 					}
-					
+
 					// If errors occured, don't replace the script tags
 					if ( ! is_null( $error ) ) {
 						continue;
@@ -121,13 +121,13 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 					$content = str_replace( $script_match, $opening_comment . $embed_content . $closing_comment, $content );
 				}
 			}
-			
+
 			return $content;
 		}
 
 		/**
 		 * Filter Broadly Headers
-		 * 
+		 *
 		 * @param $request_args original request arguments
 		 * @param $url request URL
 		 */
@@ -152,7 +152,7 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 
 		/**
 		 * Parse the type of embed from the data_uri
-		 * 
+		 *
 		 * @param $data_uri argument passed to Broadly including the embed name
 		 */
 		private function parse_embed_from_datauri( $data_uri ) {
@@ -168,7 +168,7 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 			return $embed_name;
 		}
 	}
-	
+
 	// Initialize the plugin body
 	$broadly = new Broadly_Plugin();
 }

--- a/broadly.php
+++ b/broadly.php
@@ -5,7 +5,7 @@ Description: Dynamic integration of your Broadly reviews within your existing Wo
 Plugin URL: http://broadly.com
 Author: Broadly
 Author URI: http://broadly.com/
-Version: 2.1
+Version: 2.0.1
 License: GPLv2 or later
 */
 
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 	 */
 	class Broadly_Plugin {
 
-		public static $version = '2.1';
+		public static $version = '2.0.1';
 	
 		function __construct() {
 			// Creating the admin menu

--- a/broadly.php
+++ b/broadly.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 						$error = __('Error Found ( ' . $response->get_error_message() . ' )', 'broadly' );
 					} else {
 						if ( ! empty( $response["body"] ) ) {
-							$review = $response["body"];
+							$embed_content = $response["body"];
 						} else {
 							$error = __( 'No body tag in the response', 'broadly' );
 						}
@@ -113,12 +113,12 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 					}
 
 					// Wrapper tabs
-					$review_type = $this->parse_review_from_datauri( $dataurl_match );
-					$opening_comment = sprintf( '<!-- Start of Broadly "%s" content - Broadly for WordPress %s -->', $review_type, self::$version );
-					$closing_comment = sprintf( '<!-- End of Broadly "%s" content -->', $review_type );
+					$embed_name = $this->parse_embed_from_datauri( $dataurl_match );
+					$opening_comment = sprintf( '<!-- Start of Broadly "%s" content - Broadly for WordPress %s -->', $embed_name, self::$version );
+					$closing_comment = sprintf( '<!-- End of Broadly "%s" content -->', $embed_name );
 
 					// Replace the script tag with the HTML reviews
-					$content = str_replace( $script_match, $opening_comment . $review . $closing_comment, $content );
+					$content = str_replace( $script_match, $opening_comment . $embed_content . $closing_comment, $content );
 				}
 			}
 			
@@ -151,21 +151,21 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 		}
 
 		/**
-		 * Parse the type of review from the data_uri
+		 * Parse the type of embed from the data_uri
 		 * 
-		 * @param $data_uri argument passed to Broadly including the review type
+		 * @param $data_uri argument passed to Broadly including the embed name
 		 */
-		private function parse_review_from_datauri( $data_uri ) {
+		private function parse_embed_from_datauri( $data_uri ) {
 			// Split the data uri in attempt to read the type
 			$components = explode( '/', $data_uri );
 
-			$review_type = 'reviews';
+			$embed_name = 'reviews';
 
 			if ( isset( $components[1] ) ) {
-				$review_type = $components[1];
+				$embed_name = $components[1];
 			}
 
-			return $review_type;
+			return $embed_name;
 		}
 	}
 	

--- a/broadly.php
+++ b/broadly.php
@@ -113,8 +113,9 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 					}
 
 					// Wrapper tabs
-					$opening_comment = sprintf( '<!-- Start of Broadly "reviews" content - Broadly for WordPress %s -->', self::$version );
-					$closing_comment = '<!-- End of Broadly "reviews" content -->';
+					$review_type = $this->parse_review_from_datauri( $dataurl_match );
+					$opening_comment = sprintf( '<!-- Start of Broadly "%s" content - Broadly for WordPress %s -->', $review_type, self::$version );
+					$closing_comment = sprintf( '<!-- End of Broadly "%s" content -->', $review_type );
 
 					// Replace the script tag with the HTML reviews
 					$content = str_replace( $script_match, $opening_comment . $review . $closing_comment, $content );
@@ -147,6 +148,24 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 			$request_args['headers'] = $headers;
 
 			return $request_args;
+		}
+
+		/**
+		 * Parse the type of review from the data_uri
+		 * 
+		 * @param $data_uri argument passed to Broadly including the review type
+		 */
+		private function parse_review_from_datauri( $data_uri ) {
+			// Split the data uri in attempt to read the type
+			$components = explode( '/', $data_uri );
+
+			$review_type = 'reviews';
+
+			if ( isset( $components[1] ) ) {
+				$review_type = $components[1];
+			}
+
+			return $review_type;
 		}
 	}
 	

--- a/broadly.php
+++ b/broadly.php
@@ -5,7 +5,7 @@ Description: Dynamic integration of your Broadly reviews within your existing Wo
 Plugin URL: http://broadly.com
 Author: Broadly
 Author URI: http://broadly.com/
-Version: 2.0
+Version: 2.1
 License: GPLv2 or later
 */
 
@@ -21,6 +21,8 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 	 *
 	 */
 	class Broadly_Plugin {
+
+		public static $version = '2.1';
 	
 		function __construct() {
 			// Creating the admin menu
@@ -108,8 +110,12 @@ if ( ! class_exists( 'Broadly_Plugin' ) ) {
 						continue;
 					}
 
+					// Wrapper tabs
+					$opening_comment = sprintf( '<!-- Start of Broadly "reviews" content - Broadly for WordPress %s -->', self::$version );
+					$closing_comment = '<!-- End of Broadly "reviews" content -->';
+
 					// Replace the script tag with the HTML reviews
-					$content = str_replace( $script_match, $review, $content );
+					$content = str_replace( $script_match, $opening_comment . $review . $closing_comment, $content );
 				}
 			}
 			

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: broadly
 Tested up to: 4.2.3
 Requires at least: 3.0.1
-Stable tag: 2.0
+Stable tag: 2.0.1
 Tags: broadly, marketing, smb, reviews
 
 == Description ==
@@ -46,6 +46,13 @@ Contact your Account Manager directly or contact Broadly support at either 1-800
 Learn more about Broadly at http://broadly.com.
 
 == Changelog ==
+
+= 2.0.1 =
+Release Date: September 30, 2015
+
+* Plugin adds beginning and ending comments to embed insertion code
+* Additional headers sent to Broadly for improved performance monitoring
+
 = 2.0 =
 Release Date: August 1, 2015
 


### PR DESCRIPTION
Addressing #2 #3 and #4 - the comments around the wrappers have been added.

I've also altered the headers. WordPress doesn't have a consistent filter for Referer so I had to force it and it needs testing, but I debugged the server headers on another server and I got the following output:

    array (
      'HTTP_USER_AGENT' => 'WordPress/4.4-alpha-34523; http://localhost/wpbleeding; Broadly/2.0.1',
      'HTTP_HOST' => 'dxphpci.com',
      'HTTP_ACCEPT' => '*/*',
      'HTTP_REFERER' => 'http://localhost/wpbleeding/chicago-heating/',

Let me know if that works for you and you can merge the PR to master.